### PR TITLE
[refactor] 카테고리 조회시 페이징 동적으로처리

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -64,7 +64,6 @@ export default function Home() {
 
   const getStoreList = async (searchQuery: string) => {
     try {
-      debugger
       const response = await axios.get(`${apiBaseUrl}/api/daum/search`, {
         params: {
           query: searchQuery,
@@ -151,7 +150,11 @@ export default function Home() {
             storeKey: item.storeKey,
           }),
         )
-
+        setPageLength(
+          Math.ceil(
+            response.data.pageCnt / response.data.storeCategoryList.length,
+          ),
+        )
         setStoreList(formattedData)
       }
     } catch (error) {
@@ -160,7 +163,6 @@ export default function Home() {
   }
 
   const handlePageChange = (pageNumber: number) => {
-    debugger
     if (pageNumber < 1 || pageNumber > pageLength) {
       return // 페이지 번호가 유효 범위를 벗어나면 아무 작업도 하지 않음
     }


### PR DESCRIPTION
## 관련 Issue

#24 



## 변경 사항
![조회수가적을때 페이지개수동적으로변하도록처리](https://github.com/ochoWhat2do/what2dofront/assets/42510512/d7934509-480f-4f6d-8500-1c267a19ba1b)

카테고리 조회시 페이징 동적으로처리(카카오톡1회 제공량 보다 적을때 페이지 수가 변하도록처리)

## Todo List
댓글 페이지도 페이징 적용필요