### PR TITLE
[feature]  화면에 가게 이미지 표시하도록 기능 추가

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -14,8 +14,15 @@ interface Store {
   roadAddress: string
   latitude: string
   longitude: string
-  picture: string
   storeKey: string
+  images: S3FileDto[]
+}
+
+interface S3FileDto {
+  originalFileName: string
+  uploadFileName: string
+  uploadFilePath: string
+  uploadFileUrl: string
 }
 
 export default function Home() {
@@ -146,7 +153,7 @@ export default function Home() {
             roadAddress: item.roadAddress,
             latitude: item.latitude,
             longitude: item.longitude,
-            picture: item.picture,
+            images: item.images,
             storeKey: item.storeKey,
           }),
         )
@@ -197,7 +204,7 @@ export default function Home() {
           Authorization: bearer + auth,
         },
       })
-
+      console.log(response.data)
       setStoreListByReview(response.data) // Set the fetched data to the state
     } catch (error) {
       console.error('Error fetching profile:', error)
@@ -232,15 +239,24 @@ export default function Home() {
               />
             </button>
           </div>
-          <div className={styles.title}>상위 검색순위 맛집</div>
+          <div className={styles.title}>맛집 검색결과</div>
           <div className={`flex flex-wrap ${styles['flex-store']}`}>
             {storeList.length > 0 ? (
               storeList.map((store, index) => (
-                <div key={index} className="w-1/3">
+                <div
+                  key={index}
+                  className="w-1/3"
+                  style={{ marginBottom: '20px' }}
+                >
                   {/* Adjusted class here */}
                   <section className="box feature">
                     <img
-                      src={store.picture || 'images/not_found_square.png'}
+                      className={styles.storeImage}
+                      src={
+                        store.images && store.images.length > 0
+                          ? store.images[0].uploadFileUrl
+                          : 'images/not_found_square.png'
+                      }
                       alt=""
                       onClick={() => handleViewStore(store.storeKey)}
                       style={{ cursor: 'pointer' }}
@@ -294,7 +310,12 @@ export default function Home() {
                   {/* Adjusted class here */}
                   <section className="box feature">
                     <img
-                      src={store.picture || 'images/not_found_square.png'}
+                      className={styles.storeImage}
+                      src={
+                        store.images && store.images.length > 0
+                          ? store.images[0].uploadFileUrl
+                          : 'images/not_found_square.png'
+                      }
                       alt=""
                       onClick={() => handleViewStore(store.storeKey)}
                       style={{ cursor: 'pointer' }}

--- a/src/pages/store/storeView.tsx
+++ b/src/pages/store/storeView.tsx
@@ -15,10 +15,18 @@ interface Store {
   roadAddress: string
   latitude: string
   longitude: string
-  picture: string
   storeKey: string
   isFavorite: boolean
+  images: S3FileDto[]
 }
+
+interface S3FileDto {
+  originalFileName: string
+  uploadFileName: string
+  uploadFilePath: string
+  uploadFileUrl: string
+}
+
 interface Review {
   id: number
   title: string
@@ -330,7 +338,11 @@ export default function Home() {
               <div className={styles.storeItem}>
                 <img
                   className={styles.storeImage}
-                  src={storeModel.picture || '../images/not_found_square.png'}
+                  src={
+                    storeModel.images && storeModel.images.length > 0
+                      ? storeModel.images[0].uploadFileUrl
+                      : '../images/not_found_square.png'
+                  }
                   alt=""
                 />
                 <div className={styles.storeInfo}>

--- a/src/styles/index.module.css
+++ b/src/styles/index.module.css
@@ -104,3 +104,11 @@
   color: #7a2dd2;
   margin: 20px 0 30px 100px;
 }
+
+.storeImage {
+  width: 200px;
+  height: 200px;
+  object-fit: cover;
+  margin-right: 20px;
+  border-radius: 8px;
+}

--- a/src/styles/storeView.module.css
+++ b/src/styles/storeView.module.css
@@ -30,8 +30,8 @@
 }
 
 .storeImage {
-  width: 150px;
-  height: 150px;
+  width: 200px;
+  height: 200px;
   object-fit: cover;
   margin-right: 20px;
   border-radius: 8px;


### PR DESCRIPTION
## 관련 Issue

#55 


## 변경 사항

![가게상세화면이미지반영](https://github.com/ochoWhat2do/what2dofront/assets/42510512/dda9e386-eb0c-48d0-841a-245271d2d6b7)

-화면에 가게 이미지 표시하도록 기능 추가(메인, 상세화면) 

## Todo List

- 상세화면 최초 클릭 시 이미지가 보이도록 처리 
- 관리자 이미지 수동등록 기능 추가 

## Check List


## 트러블 슈팅

이미지가 불러와지지 않는현상
-> 스케줄러 실행 후 이미지 대량으로 반영
-> 반영안된 페이지는 수동으로 등록 처리 
